### PR TITLE
fix: upgrade Node.js version to 20 in GitHub Actions

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -31,7 +31,7 @@ jobs:
     - name: Setup Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: '18'
+        node-version: '20'
         cache: 'npm'
         cache-dependency-path: frontend/package-lock.json
     


### PR DESCRIPTION
- Updated node-version from '18' to '20' in e2e-tests workflow
- Vite 7.1.7 requires Node.js 20.19+ or 22.12+
- Fixes crypto.hash is not a function error in GitHub Actions