### PR TITLE
fix: corrige teste unitário para usar InvalidOperationException

### DIFF
--- a/backend/src/StackShare.Application/Features/Stacks/CreateStack.cs
+++ b/backend/src/StackShare.Application/Features/Stacks/CreateStack.cs
@@ -99,7 +99,7 @@ public class CreateStackHandler : IRequestHandler<CreateStackRequest, StackRespo
 
             if (existingTechById.Count != request.TechnologyIds.Count)
             {
-                throw new ArgumentException("Uma ou mais tecnologias por ID não foram encontradas ou estão inativas");
+                throw new InvalidOperationException("Uma ou mais tecnologias por ID não foram encontradas ou estão inativas");
             }
 
             allTechnologyIds.AddRange(existingTechById.Select(t => t.Id));

--- a/backend/tests/StackShare.UnitTests/Features/Stacks/CreateStackHandlerTests.cs
+++ b/backend/tests/StackShare.UnitTests/Features/Stacks/CreateStackHandlerTests.cs
@@ -104,7 +104,7 @@ public class CreateStackHandlerTests : IDisposable
 
         // Act & Assert
         var act = () => _handler.Handle(request, CancellationToken.None);
-        await act.Should().ThrowAsync<ArgumentException>()
+        await act.Should().ThrowAsync<InvalidOperationException>()
             .WithMessage("Uma ou mais tecnologias por ID não foram encontradas ou estão inativas");
     }
 


### PR DESCRIPTION
- Ajusta teste Handle_InvalidTechnologyId_ShouldThrowArgumentException para esperar InvalidOperationException
- Mantém consistência com o middleware GlobalExceptionMiddleware que mapeia InvalidOperationException para BadRequest (400)
- Garante que tanto testes unitários quanto de integração passem
- Resolve completamente a falha na GitHub Actions