### PR TITLE
fix: correct Docker build context in GitHub Actions workflows

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -141,7 +141,7 @@ jobs:
     - name: Build and push API image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./backend
         file: ./backend/src/StackShare.API/Dockerfile
         push: true
         tags: ${{ steps.meta-api.outputs.tags }}
@@ -153,7 +153,7 @@ jobs:
     - name: Build and push MCP image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./backend
         file: ./backend/src/StackShare.McpServer/Dockerfile
         push: true
         tags: ${{ steps.meta-mcp.outputs.tags }}

--- a/.github/workflows/mcp.yml
+++ b/.github/workflows/mcp.yml
@@ -95,7 +95,7 @@ jobs:
     - name: Build and push MCP image
       uses: docker/build-push-action@v5
       with:
-        context: .
+        context: ./backend
         file: ./backend/src/StackShare.McpServer/Dockerfile
         push: true
         tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -91,10 +91,10 @@ jobs:
         component:
           - name: api
             dockerfile: ./backend/src/StackShare.API/Dockerfile
-            context: .
+            context: ./backend
           - name: mcp
             dockerfile: ./backend/src/StackShare.McpServer/Dockerfile
-            context: .
+            context: ./backend
           - name: frontend
             dockerfile: ./frontend/Dockerfile
             context: ./frontend


### PR DESCRIPTION
- Changed context from '.' to './backend' for API and MCP images
- This resolves the issue where Docker could not find project files
- Affects workflows: backend.yml, mcp.yml, and release.yml
- Now matches the working docker-compose.yml configuration